### PR TITLE
Upgrade to Prisma 5.13.0-dev.30

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,15 +7,15 @@ importers:
 
   ../../services/prisma-test:
     specifiers:
-      '@prisma/client': ~4.11.0
+      '@prisma/client': ~5.7.0
       '@rushstack/heft': ~0.49.7
-      prisma: ~4.11.0
+      prisma: ~5.7.0
       typescript: ~4.9.3
     dependencies:
-      '@prisma/client': 4.11.0_prisma@4.11.0
+      '@prisma/client': 5.7.0_prisma@5.7.0
       '@rushstack/heft': 0.49.7
     devDependencies:
-      prisma: 4.11.0
+      prisma: 5.7.0
       typescript: 4.9.4
 
 packages:
@@ -41,9 +41,9 @@ packages:
       fastq: 1.15.0
     dev: false
 
-  /@prisma/client/4.11.0_prisma@4.11.0:
-    resolution: {integrity: sha512-0INHYkQIqgAjrt7NzhYpeDQi8x3Nvylc2uDngKyFDDj1tTRQ4uV1HnVmd1sQEraeVAN63SOK0dgCKQHlvjL0KA==}
-    engines: {node: '>=14.17'}
+  /@prisma/client/5.7.0_prisma@5.7.0:
+    resolution: {integrity: sha512-cZmglCrfNbYpzUtz7HscVHl38e9CrUs31nrVoGUK1nIPXGgt8hT4jj2s657UXcNdQ/jBUxDgGmHyu2Nyrq1txg==}
+    engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
       prisma: '*'
@@ -51,17 +51,39 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 4.11.0-57.8fde8fef4033376662cad983758335009d522acb
-      prisma: 4.11.0
+      prisma: 5.7.0
     dev: false
 
-  /@prisma/engines-version/4.11.0-57.8fde8fef4033376662cad983758335009d522acb:
-    resolution: {integrity: sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g==}
-    dev: false
+  /@prisma/debug/5.7.0:
+    resolution: {integrity: sha512-tZ+MOjWlVvz1kOEhNYMa4QUGURY+kgOUBqLHYIV8jmCsMuvA1tWcn7qtIMLzYWCbDcQT4ZS8xDgK0R2gl6/0wA==}
+    dev: true
 
-  /@prisma/engines/4.11.0:
-    resolution: {integrity: sha512-0AEBi2HXGV02cf6ASsBPhfsVIbVSDC9nbQed4iiY5eHttW9ZtMxHThuKZE1pnESbr8HRdgmFSa/Kn4OSNYuibg==}
+  /@prisma/engines-version/5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9:
+    resolution: {integrity: sha512-V6tgRVi62jRwTm0Hglky3Scwjr/AKFBFtS+MdbsBr7UOuiu1TKLPc6xfPiyEN1+bYqjEtjxwGsHgahcJsd1rNg==}
+    dev: true
+
+  /@prisma/engines/5.7.0:
+    resolution: {integrity: sha512-TkOMgMm60n5YgEKPn9erIvFX2/QuWnl3GBo6yTRyZKk5O5KQertXiNnrYgSLy0SpsKmhovEPQb+D4l0SzyE7XA==}
     requiresBuild: true
+    dependencies:
+      '@prisma/debug': 5.7.0
+      '@prisma/engines-version': 5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9
+      '@prisma/fetch-engine': 5.7.0
+      '@prisma/get-platform': 5.7.0
+    dev: true
+
+  /@prisma/fetch-engine/5.7.0:
+    resolution: {integrity: sha512-zIn/qmO+N/3FYe7/L9o+yZseIU8ivh4NdPKSkQRIHfg2QVTVMnbhGoTcecbxfVubeTp+DjcbjS0H9fCuM4W04w==}
+    dependencies:
+      '@prisma/debug': 5.7.0
+      '@prisma/engines-version': 5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9
+      '@prisma/get-platform': 5.7.0
+    dev: true
+
+  /@prisma/get-platform/5.7.0:
+    resolution: {integrity: sha512-ZeV/Op4bZsWXuw5Tg05WwRI8BlKiRFhsixPcAM+5BKYSiUZiMKIi713tfT3drBq8+T0E1arNZgYSA9QYcglWNA==}
+    dependencies:
+      '@prisma/debug': 5.7.0
     dev: true
 
   /@rushstack/heft-config-file/0.11.9:
@@ -415,13 +437,13 @@ packages:
     hasBin: true
     dev: false
 
-  /prisma/4.11.0:
-    resolution: {integrity: sha512-4zZmBXssPUEiX+GeL0MUq/Yyie4ltiKmGu7jCJFnYMamNrrulTBc+D+QwAQSJ01tyzeGHlD13kOnqPwRipnlNw==}
-    engines: {node: '>=14.17'}
+  /prisma/5.7.0:
+    resolution: {integrity: sha512-0rcfXO2ErmGAtxnuTNHQT9ztL0zZheQjOI/VNJzdq87C3TlGPQtMqtM+KCwU6XtmkoEr7vbCQqA7HF9IY0ST+Q==}
+    engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 4.11.0
+      '@prisma/engines': 5.7.0
     dev: true
 
   /queue-microtask/1.2.3:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,15 +7,15 @@ importers:
 
   ../../services/prisma-test:
     specifiers:
-      '@prisma/client': ~5.7.0
+      '@prisma/client': 5.13.0-dev.30
       '@rushstack/heft': ~0.49.7
-      prisma: ~5.7.0
+      prisma: 5.13.0-dev.30
       typescript: ~4.9.3
     dependencies:
-      '@prisma/client': 5.7.0_prisma@5.7.0
+      '@prisma/client': 5.13.0-dev.30_prisma@5.13.0-dev.30
       '@rushstack/heft': 0.49.7
     devDependencies:
-      prisma: 5.7.0
+      prisma: 5.13.0-dev.30
       typescript: 4.9.4
 
 packages:
@@ -41,8 +41,8 @@ packages:
       fastq: 1.15.0
     dev: false
 
-  /@prisma/client/5.7.0_prisma@5.7.0:
-    resolution: {integrity: sha512-cZmglCrfNbYpzUtz7HscVHl38e9CrUs31nrVoGUK1nIPXGgt8hT4jj2s657UXcNdQ/jBUxDgGmHyu2Nyrq1txg==}
+  /@prisma/client/5.13.0-dev.30_prisma@5.13.0-dev.30:
+    resolution: {integrity: sha512-uGcYxO1csfsewcGXQkeEmcSINVN/0pqe2d6FXZJAmrgvWlsKxgHprQx4G7TOe5hqHSGm1BF+0tKWvbhHIhMcEw==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -51,39 +51,39 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: 5.7.0
+      prisma: 5.13.0-dev.30
     dev: false
 
-  /@prisma/debug/5.7.0:
-    resolution: {integrity: sha512-tZ+MOjWlVvz1kOEhNYMa4QUGURY+kgOUBqLHYIV8jmCsMuvA1tWcn7qtIMLzYWCbDcQT4ZS8xDgK0R2gl6/0wA==}
+  /@prisma/debug/5.13.0-dev.30:
+    resolution: {integrity: sha512-TYaG9imtnKP10FjLaJyprQ9j/wNQnEXA/ROKmLVhH8q2qM/i/LQmnbl9sVGTXT6NaMA0oTfbm574F9J/FRriGA==}
     dev: true
 
-  /@prisma/engines-version/5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9:
-    resolution: {integrity: sha512-V6tgRVi62jRwTm0Hglky3Scwjr/AKFBFtS+MdbsBr7UOuiu1TKLPc6xfPiyEN1+bYqjEtjxwGsHgahcJsd1rNg==}
+  /@prisma/engines-version/5.13.0-16.6d35870e9578a3e7406168f61f89f84e78c1b38d:
+    resolution: {integrity: sha512-HYGlQyXltWQ0Js9WwQz4mH5i+TwqK28GiVdi8i7MNfSMSv+7ITXGVp0TTVEqXEmv1D3t6pzaXYjzFctcLnIfHw==}
     dev: true
 
-  /@prisma/engines/5.7.0:
-    resolution: {integrity: sha512-TkOMgMm60n5YgEKPn9erIvFX2/QuWnl3GBo6yTRyZKk5O5KQertXiNnrYgSLy0SpsKmhovEPQb+D4l0SzyE7XA==}
+  /@prisma/engines/5.13.0-dev.30:
+    resolution: {integrity: sha512-7GrRp5AkW/liJD3Z2UcQ4i1zQyb7DXJUIcuukwJKnjd4VbwHukoY6g0R1I+pQvufiJh2JfUmecT2x33JAQqo1g==}
     requiresBuild: true
     dependencies:
-      '@prisma/debug': 5.7.0
-      '@prisma/engines-version': 5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9
-      '@prisma/fetch-engine': 5.7.0
-      '@prisma/get-platform': 5.7.0
+      '@prisma/debug': 5.13.0-dev.30
+      '@prisma/engines-version': 5.13.0-16.6d35870e9578a3e7406168f61f89f84e78c1b38d
+      '@prisma/fetch-engine': 5.13.0-dev.30
+      '@prisma/get-platform': 5.13.0-dev.30
     dev: true
 
-  /@prisma/fetch-engine/5.7.0:
-    resolution: {integrity: sha512-zIn/qmO+N/3FYe7/L9o+yZseIU8ivh4NdPKSkQRIHfg2QVTVMnbhGoTcecbxfVubeTp+DjcbjS0H9fCuM4W04w==}
+  /@prisma/fetch-engine/5.13.0-dev.30:
+    resolution: {integrity: sha512-zfEu2XJCgUVT3iEu9r9g19JXLI6Uh/+YY00jDl0i/BqMv5Fnu2b+hp7hfAYfFHXHngaSyvoJQZEqTLnEjrg/ZA==}
     dependencies:
-      '@prisma/debug': 5.7.0
-      '@prisma/engines-version': 5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9
-      '@prisma/get-platform': 5.7.0
+      '@prisma/debug': 5.13.0-dev.30
+      '@prisma/engines-version': 5.13.0-16.6d35870e9578a3e7406168f61f89f84e78c1b38d
+      '@prisma/get-platform': 5.13.0-dev.30
     dev: true
 
-  /@prisma/get-platform/5.7.0:
-    resolution: {integrity: sha512-ZeV/Op4bZsWXuw5Tg05WwRI8BlKiRFhsixPcAM+5BKYSiUZiMKIi713tfT3drBq8+T0E1arNZgYSA9QYcglWNA==}
+  /@prisma/get-platform/5.13.0-dev.30:
+    resolution: {integrity: sha512-dWs6zaiS2gCYII8KGaI5GyZI2j0kOdGLBiKxz6i5qNzHTdgBj0wE13fW67FmHxmnt7dx5hwrX847V4T8Sr3JFA==}
     dependencies:
-      '@prisma/debug': 5.7.0
+      '@prisma/debug': 5.13.0-dev.30
     dev: true
 
   /@rushstack/heft-config-file/0.11.9:
@@ -437,13 +437,13 @@ packages:
     hasBin: true
     dev: false
 
-  /prisma/5.7.0:
-    resolution: {integrity: sha512-0rcfXO2ErmGAtxnuTNHQT9ztL0zZheQjOI/VNJzdq87C3TlGPQtMqtM+KCwU6XtmkoEr7vbCQqA7HF9IY0ST+Q==}
+  /prisma/5.13.0-dev.30:
+    resolution: {integrity: sha512-m2ldoiKJnYUun24wkmtGV8zKW9nNd8o3u2pYIN89JvwX2/DEan0dNmuS3uL7UOLir8C/Oo2U02XFNynucBjHzQ==}
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.7.0
+      '@prisma/engines': 5.13.0-dev.30
     dev: true
 
   /queue-microtask/1.2.3:

--- a/rush.json
+++ b/rush.json
@@ -4,7 +4,6 @@
  */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-
   /**
    * (Required) This specifies the version of the Rush engine to be used in this repo.
    * Rush's "version selector" feature ensures that the globally installed tool will
@@ -17,7 +16,6 @@
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
   "rushVersion": "5.83.3",
-
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process
@@ -27,10 +25,8 @@
    * for details about these alternatives.
    */
   "pnpmVersion": "6.7.1",
-
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",
-
   /**
    * Options that are only used when the PNPM package manager is selected
    */
@@ -51,7 +47,6 @@
      * The default value is "local".
      */
     // "pnpmStore": "local",
-
     /**
      * If true, then Rush will add the "--strict-peer-dependencies" option when invoking PNPM.
      * This causes "rush install" to fail if there are unsatisfied peer dependencies, which is
@@ -63,7 +58,6 @@
      * It is strongly recommended to set strictPeerDependencies=true.
      */
     // "strictPeerDependencies": true,
-
     /**
      * Configures the strategy used to select versions during installation.
      *
@@ -77,7 +71,6 @@
      * will recalculate all version selections.
      */
     // "resolutionStrategy": "fast",
-
     /**
      * If true, then `rush install` will report an error if manual modifications
      * were made to the PNPM shrinkwrap file without running "rush update" afterwards.
@@ -95,7 +88,6 @@
      * The default value is false.
      */
     // "preventManualShrinkwrapChanges": true,
-
     /**
      * If true, then `rush install` will use the PNPM workspaces feature to perform the
      * install.
@@ -110,9 +102,8 @@
      *
      * This option is experimental. The default value is false.
      */
-     "useWorkspaces": true
+    "useWorkspaces": true
   },
-
   /**
    * Older releases of the Node.js engine may be missing features required by your system.
    * Other releases may have bugs.  In particular, the "latest" version will not be a
@@ -124,8 +115,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=16.13.0 <17.0.0",
-
+  "nodeSupportedVersionRange": ">=18.16.0 <19.0.0",
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases
    * spend six months in a stabilization period before the first Long Term Support (LTS) version.
@@ -138,7 +128,6 @@
    * to disable Rush's warning.
    */
   // "suppressNodeLtsWarning": false,
-
   /**
    * If you would like the version specifiers for your dependencies to be consistent, then
    * uncomment this line. This is effectively similar to running "rush check" before any
@@ -151,7 +140,6 @@
    * section of the common-versions.json.
    */
   "ensureConsistentVersions": true,
-
   /**
    * Large monorepos can become intimidating for newcomers if project folder paths don't follow
    * a consistent and recognizable pattern.  When the system allows nested folder trees,
@@ -177,7 +165,6 @@
    */
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,
-
   /**
    * Today the npmjs.com registry enforces fairly strict naming rules for packages, but in the early
    * days there was no standard and hardly any enforcement.  A few large legacy projects are still using
@@ -190,7 +177,6 @@
    * The default value is false.
    */
   // "allowMostlyStandardPackageNames": true,
-
   /**
    * This feature helps you to review and approve new packages before they are introduced
    * to your monorepo.  For example, you may be concerned about licensing, code quality,
@@ -226,7 +212,6 @@
   //    */
   //   // "ignoredNpmScopes": ["@types"]
   // },
-
   /**
    * If you use Git as your version control system, this section has some additional
    * optional features you can use.
@@ -247,14 +232,12 @@
     //   "[^@]+@users\\.noreply\\.github\\.com",
     //   "travis@example\\.org"
     // ],
-
     /**
      * When Rush reports that the address is malformed, the notice can include an example
      * of a recommended email.  Make sure it conforms to one of the allowedEmailRegExps
      * expressions.
      */
     // "sampleEmail": "mrexample@users.noreply.github.com",
-
     /**
      * The commit message to use when committing changes during 'rush publish'.
      *
@@ -263,7 +246,6 @@
      * in the commit message, and then customize Rush's message to contain that string.
      */
     // "versionBumpCommitMessage": "Bump versions [skip ci]",
-
     /**
      * The commit message to use when committing changes during 'rush version'.
      *
@@ -273,7 +255,6 @@
      */
     // "changeLogUpdateCommitMessage": "Update changelogs [skip ci]"
   },
-
   "repository": {
     /**
      * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
@@ -291,20 +272,17 @@
      * to retrieve the latest activity for the remote master branch.
      */
     // "url": "https://github.com/microsoft/rush-example",
-
     /**
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "master"
      */
     // "defaultBranch": "main",
-
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is
      * not set or if a remote matching the provided remote URL is not found.
      */
     // "defaultRemote": "origin"
   },
-
   /**
    * Event hooks are customized script actions that Rush executes when specific events occur
    */
@@ -315,23 +293,19 @@
     "preRushInstall": [
       // "common/scripts/pre-rush-install.js"
     ],
-
     /**
      * The list of shell commands to run after the Rush installation finishes
      */
     "postRushInstall": [],
-
     /**
      * The list of shell commands to run before the Rush build command starts
      */
     "preRushBuild": [],
-
     /**
      * The list of shell commands to run after the Rush build command finishes
      */
     "postRushBuild": []
   },
-
   /**
    * Installation variants allow you to maintain a parallel set of configuration files that can be
    * used to build the entire monorepo with an alternate set of dependencies.  For example, suppose
@@ -362,7 +336,6 @@
     //   "description": "Build this repo using the previous release of the SDK"
     // }
   ],
-
   /**
    * Rush can collect anonymous telemetry about everyday developer activity such as
    * success/failure of installs, builds, and other operations.  You can use this to identify
@@ -372,14 +345,12 @@
    * in the "eventHooks" section.
    */
   // "telemetryEnabled": false,
-
   /**
    * Allows creation of hotfix changes. This feature is experimental so it is disabled by default.
    * If this is set, 'rush change' only allows a 'hotfix' change type to be specified. This change type
    * will be used when publishing subsequent changes from the monorepo.
    */
   // "hotfixChangeEnabled": false,
-
   /**
    * (Required) This is the inventory of projects to be managed by Rush.
    *

--- a/services/prisma-test/package.json
+++ b/services/prisma-test/package.json
@@ -10,11 +10,11 @@
         "run": "prisma generate && heft build --clean && cp -r ./src/__generated__ ./lib && node ./lib/index.js"
     },
     "dependencies": {
-        "@prisma/client": "~4.11.0",
+        "@prisma/client": "~5.7.0",
         "@rushstack/heft": "~0.49.7"
     },
     "devDependencies": {
-        "prisma": "~4.11.0",
+        "prisma": "~5.7.0",
         "typescript": "~4.9.3"
     },
     "prisma": {}

--- a/services/prisma-test/package.json
+++ b/services/prisma-test/package.json
@@ -10,11 +10,11 @@
         "run": "prisma generate && heft build --clean && cp -r ./src/__generated__ ./lib && node ./lib/index.js"
     },
     "dependencies": {
-        "@prisma/client": "~5.7.0",
+        "@prisma/client": "5.13.0-dev.30",
         "@rushstack/heft": "~0.49.7"
     },
     "devDependencies": {
-        "prisma": "~5.7.0",
+        "prisma": "5.13.0-dev.30",
         "typescript": "~4.9.3"
     },
     "prisma": {}


### PR DESCRIPTION
Error on 5.7.0
```
Upserting person
thread 'tokio-runtime-worker' panicked at query-engine/core/src/response_ir/ir_serializer.rs:57:40:
Internal error: Attempted to serialize empty result.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered error
Invalid `prisma.employee.upsert()` invocation in
/Volumes/git/prisma-upsert-debugging/services/prisma-test/lib/index.js:10:27

   7 const employeeCreate = {
   8     emailAddress: "test_employee@test.com",
   9 };
→ 10 await prisma.employee.upsert(
Internal error: Attempted to serialize empty result.

This is a non-recoverable error which probably happens when the Prisma Query Engine has a panic.
```

On 5.13.0-dev.30
```
Upserting person
Upsert successful
```
